### PR TITLE
:new: [exceptions] Fail on active exception

### DIFF
--- a/example/exceptions.cpp
+++ b/example/exceptions.cpp
@@ -16,5 +16,6 @@ int main() {
         << "throws runtime_error";
     expect(throws([] { throw 0; })) << "throws any exception";
     expect(nothrow([] {})) << "doesn't throw";
+    // expect([] { throw std::runtime_error{""}; return true; }()); // fail
   };
 }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -154,7 +154,13 @@ class default_cfg {
         out_ << "\n \"" << test.name << "\"...";
       }
 
-      test.test();
+      active_exception_ = false;
+      try {
+        test.test();
+      } catch (...) {
+        out_ << "\n  Unexpected exception!";
+        active_exception_ = true;
+      }
 
       if (not--level_) {
         test_end();
@@ -224,7 +230,7 @@ class default_cfg {
   }
 
   auto test_end() -> void {
-    if (asserts_.fail > fails_) {
+    if (asserts_.fail > fails_ or active_exception_) {
       ++tests_.fail;
       out_ << "\nFAILED\n";
     } else {
@@ -248,6 +254,7 @@ class default_cfg {
 
   std::size_t fails_{};
   std::size_t level_{};
+  bool active_exception_{};
 };
 
 struct override {};

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -24,7 +24,10 @@ struct fake_cfg {
   auto on(ut::events::test_run<Test> test) {
     if (std::empty(test_filter) or test.name == test_filter) {
       test_calls.push_back(test.name);
-      test.test();
+      try {
+        test.test();
+      } catch (...) {
+      }
     }
   }
   template <class Test>
@@ -203,6 +206,16 @@ int main() {
           << "throws runtime_error";
       expect(throws([] { throw 0; })) << "throws any exception";
       expect(nothrow([] {})) << "doesn't throw";
+    };
+
+    test_assert(3 == std::size(test_cfg.assertion_calls));
+
+    "should throw"_test = [] {
+      auto f = [](const auto should_throw) {
+        if (should_throw) throw 42;
+        return 42;
+      };
+      expect(42_i == f(true));
     };
 
     test_assert(3 == std::size(test_cfg.assertion_calls));


### PR DESCRIPTION
Problem:
- Abort is called on active exception and tests aren't failing.

Solution:
- Handle active exception and report a failure.