### PR TITLE
add build options and install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,9 @@ add_custom_command(TARGET style COMMAND find ${CMAKE_CURRENT_LIST_DIR}/benchmark
 option(ENABLE_MEMCHECK "Run the unit tests and examples under valgrind if it is found." OFF)
 option(ENABLE_COVERAGE "Run coverage." OFF)
 option(ENABLE_SANITIZERS "Run static analysis." OFF)
+option(BUILD_BENCHMARKS "Enable building the benchmarks" ON)
+option(BUILD_EXAMPLES "Enable building the examples" ON)
+option(BUILD_TESTS "Enable building the tests" ON)
 
 if (ENABLE_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
@@ -75,6 +78,15 @@ endif()
 
 enable_testing()
 include_directories(include)
-add_subdirectory(benchmark)
-add_subdirectory(example)
-add_subdirectory(test)
+
+if (BUILD_BENCHMARKS)
+  add_subdirectory(benchmark)
+endif()
+if (BUILD_EXAMPLES)
+  add_subdirectory(example)
+endif()
+if (BUILD_TESTS)
+  add_subdirectory(test)
+endif()
+
+install(FILES include/boost/ut.hpp DESTINATION include/boost/)


### PR DESCRIPTION
this patch adds build options to disable building the tests, examples and benchmarks as well as adds an install target