### PR TITLE
:new: :art: [ut] Nicely print `throws/nothrow/aborts` info on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,15 @@ asserts: 16 | 14 passed | 2 failed
 All tests passed (4 asserts in 1 tests)
 ```
 
-**Exceptions** (https://godbolt.org/z/3BdTtA)
+**Exceptions/Aborts** (https://godbolt.org/z/3BdTtA)
 
 ```cpp
-"exceptions"_test = [] {
+"exceptions/aborts"_test = [] {
   expect(throws<std::runtime_error>([]{throw std::runtime_error{""};}))
     << "throws runtime_error";
   expect(throws([]{throw 0;})) << "throws any exception";
   expect(nothrow([]{})) << "doesn't throw";
+  expect(aborts([] { assert(false); }));
 };
 ```
 

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1371,6 +1371,11 @@ class throws_ : op {
     return false;
   }
 
+  template <class TOs>
+  friend auto operator<<(TOs& os, const throws_&) -> TOs& {
+    return (os << "throws<" << reflection::type_name<TException>() << ">");
+  }
+
  private:
   TExpr expr_{};
 };
@@ -1389,6 +1394,11 @@ class throws_<TExpr, void> : op {
     return false;
   }
 
+  template <class TOs>
+  friend auto operator<<(TOs& os, const throws_&) -> TOs& {
+    return (os << "throws");
+  }
+
  private:
   TExpr expr_{};
 };
@@ -1405,6 +1415,11 @@ class nothrow_ : op {
       return false;
     }
     return true;
+  }
+
+  template <class TOs>
+  friend auto operator<<(TOs& os, const nothrow_&) -> TOs& {
+    return (os << "nothrow");
   }
 
  private:
@@ -1426,6 +1441,11 @@ class aborts_ : op {
     auto exit_status = 0;
     wait(&exit_status);
     return exit_status;
+  }
+
+  template <class TOs>
+  friend auto operator<<(TOs& os, const aborts_&) -> TOs& {
+    return (os << "aborts");
   }
 
  private:

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -141,6 +141,13 @@ int main() {
   {
     static_assert("void"sv == std::string_view{reflection::type_name<void>()});
     static_assert("int"sv == std::string_view{reflection::type_name<int>()});
+#if defined(_MSC_VER)
+    static_assert("struct fake_cfg"sv ==
+                  std::string_view{reflection::type_name<fake_cfg>()});
+#else
+    static_assert("fake_cfg"sv ==
+                  std::string_view{reflection::type_name<fake_cfg>()});
+#endif
   }
 
   {
@@ -822,17 +829,33 @@ int main() {
     test_assert("exceptions"sv == test_cfg.run_calls[0].name);
     test_assert(6 == std::size(test_cfg.assertion_calls));
     test_assert(test_cfg.assertion_calls[0].result);
-    test_assert("true" == test_cfg.assertion_calls[0].str);
+#if defined(_MSC_VER)
+    test_assert("throws<class std::runtime_error>" ==
+                test_cfg.assertion_calls[0].str);
     test_assert(test_cfg.assertion_calls[1].result);
-    test_assert("true" == test_cfg.assertion_calls[1].str);
+    test_assert("throws" == test_cfg.assertion_calls[1].str);
     test_assert(not test_cfg.assertion_calls[2].result);
-    test_assert("false" == test_cfg.assertion_calls[2].str);
+    test_assert("throws<class std::runtime_error>" ==
+                test_cfg.assertion_calls[2].str);
     test_assert(not test_cfg.assertion_calls[3].result);
-    test_assert("false" == test_cfg.assertion_calls[3].str);
+    test_assert("throws<class std::runtime_error>" ==
+                test_cfg.assertion_calls[3].str);
+#else
+    test_assert("throws<std::runtime_error>" ==
+                test_cfg.assertion_calls[0].str);
+    test_assert(test_cfg.assertion_calls[1].result);
+    test_assert("throws" == test_cfg.assertion_calls[1].str);
+    test_assert(not test_cfg.assertion_calls[2].result);
+    test_assert("throws<std::runtime_error>" ==
+                test_cfg.assertion_calls[2].str);
+    test_assert(not test_cfg.assertion_calls[3].result);
+    test_assert("throws<std::runtime_error>" ==
+                test_cfg.assertion_calls[3].str);
+#endif
     test_assert(test_cfg.assertion_calls[4].result);
-    test_assert("true" == test_cfg.assertion_calls[4].str);
+    test_assert("nothrow" == test_cfg.assertion_calls[4].str);
     test_assert(not test_cfg.assertion_calls[5].result);
-    test_assert("false" == test_cfg.assertion_calls[5].str);
+    test_assert("nothrow" == test_cfg.assertion_calls[5].str);
 
     "should throw"_test = [] {
       auto f = [](const auto should_throw) {
@@ -860,7 +883,9 @@ int main() {
     test_assert("abort"sv == test_cfg.run_calls[0].name);
     test_assert(2 == std::size(test_cfg.assertion_calls));
     test_assert(not test_cfg.assertion_calls[0].result);
+    test_assert("aborts" == test_cfg.assertion_calls[0].str);
     test_assert(test_cfg.assertion_calls[1].result);
+    test_assert("aborts" == test_cfg.assertion_calls[1].str);
   }
 #endif
 


### PR DESCRIPTION
Problem:
-

Solution:
-

Issue: #

Reviewers:
@
