### PR TITLE
:art: :new: [example] Extend `section` example with move-only types

### DIFF
--- a/example/section.cpp
+++ b/example/section.cpp
@@ -6,6 +6,8 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #include <boost/ut.hpp>
+#include <sstream>
+#include <string_view>
 #include <vector>
 
 int main() {
@@ -27,5 +29,19 @@ int main() {
       v.resize(0);
       expect(0_ul == std::size(v));
     };
+  };
+
+  using namespace std::literals;
+
+  std::stringstream str{};
+
+  "[str1]"_test = [str{std::move(str)}] {
+    mut(str) << '1';
+    expect(str.str() == "1"sv);
+  };
+
+  "[str2]"_test = [str{std::move(str)}] {
+    mut(str) << '2';
+    expect(str.str() == "2"sv);
   };
 }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1459,8 +1459,8 @@ struct skip {};
 
 #if defined(BOOST_UT_FORWARD)
 template <class..., class TEvent>
-constexpr auto on(const TEvent& event) {
-  link::on(event);
+constexpr auto on(TEvent&& event) {
+  link::on(static_cast<TEvent&&>(event));
 }
 
 template <class..., class Test, class TArg>
@@ -1481,9 +1481,9 @@ template <class..., class TExpr>
 }
 #else
 template <class... Ts, class TEvent>
-[[nodiscard]] constexpr decltype(auto) on(const TEvent& event) {
+[[nodiscard]] constexpr decltype(auto) on(TEvent&& event) {
   return ut::cfg<typename type_traits::identity<override, Ts...>::type>.on(
-      event);
+      static_cast<TEvent&&>(event));
 }
 #endif
 
@@ -1517,8 +1517,11 @@ struct test {
                 not type_traits::is_convertible_v<Test, void (*)()>> = 0>
   constexpr auto operator=(Test test) ->
       typename type_traits::identity<Test, decltype(test())>::type {
-    on<Test>(events::test<Test>{
-        .type = type, .name = name, .location = {}, .arg = {}, .run = test});
+    on<Test>(events::test<Test>{.type = type,
+                                .name = name,
+                                .location = {},
+                                .arg = {},
+                                .run = static_cast<Test&&>(test)});
     return test;
   }
 


### PR DESCRIPTION
Problem:
- `section` example doesn't show how to deal with move-only types.

Solution:
- Add 2 additional tests which show how move move-only types into tests (based on std::stringstream).

