### PR TITLE
:bug: [example] Runner Example Segfaults, Fix #271

### DIFF
--- a/example/cfg/runner.cpp
+++ b/example/cfg/runner.cpp
@@ -6,6 +6,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 #include <boost/ut.hpp>
+#include <stdexcept>
 
 namespace ut = boost::ut;
 
@@ -36,7 +37,7 @@ int main() {
   using namespace ut;
 
   "should be ignored"_test = [] {
-    expect(throws([] { throw std::runtime_error{{}}; }));
+    expect(throws([] { throw std::runtime_error{"exception!"}; }));
     expect(1_i == 2) << "doesn't fire";
   };
 }

--- a/example/exception.cpp
+++ b/example/exception.cpp
@@ -12,8 +12,9 @@ int main() {
   using namespace boost::ut;
 
   "exceptions"_test = [] {
-    expect(throws<std::runtime_error>([] { throw std::runtime_error{""}; }))
-        << "throws runtime_error";
+    expect(throws<std::runtime_error>([] {
+      throw std::runtime_error{"exception!"};
+    })) << "throws runtime_error";
     expect(throws([] { throw 0; })) << "throws any exception";
     expect(nothrow([] {})) << "doesn't throw";
   };


### PR DESCRIPTION
Problem:
- `runtime_error` with an empty `{}` is being thrown causing UB.
- There is missing `stdexcept` include.

Solution:
- Use a `"exception!"` string instead.
- Add missing include.
