### PR TITLE
:new: [example] Parallel execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ matrix:
     env: CXX=clang++ VARIANT=valgrind
 
 script:
+  - git clone --depth 1 https://github.com/intel/tbb.git
+  - export TBB_ROOT="$PWD/tbb"
   - if [ "${VARIANT}" == "valgrind" ]; then (
       cmake -Bbuild/debug -DCMAKE_BUILD_TYPE=Debug -DENABLE_MEMCHECK=ON -H. && cmake --build build/debug &&
       cmake -Bbuild/release -DCMAKE_BUILD_TYPE=Release -DENABLE_MEMCHECK=ON -H. && cmake --build build/release

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There are quite a few problems with the approach above
 * No names for tests (Hard to follow intentions by further readers)
 * No automatic registration of tests (No way to run specific tests)
 * Hard to debug (Assertions don't provide any information why it failed)
-* Hard to scale (No easy path forward for parameterized tests, multiple suites, etc...)
+* Hard to scale (No easy path forward for parameterized tests, multiple suites, parallel execution, etc...)
 * Hard to integrate (No easy way to have a custom output such as XML for CI integration)
 * Easy to make mistakes (With implicit casting, floating point comparison, pointer comparison for strings, etc...)
 * Hard to follow good practises such as TDD/BDD (Lack of support for sections and declarative expressions)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -21,6 +21,16 @@ endif()
 
 example(cfg/printer printer)
 example(cfg/runner runner)
+
+example(cfg/parallel_runner parallel_runner)
+if (DEFINED ENV{TBB_ROOT})
+  set(TBB_ROOT $ENV{TBB_ROOT})
+  include(${TBB_ROOT}/cmake/TBBBuild.cmake)
+  tbb_build(TBB_ROOT ${TBB_ROOT} CONFIG_DIR TBB_DIR MAKE_ARGS stdver="c++17")
+  find_package(TBB)
+  target_link_libraries(parallel_runner ${TBB_IMPORTED_TARGETS})
+endif()
+
 example(cfg/reporter reporter)
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   example(abort abort)

--- a/example/cfg/parallel_runner.cpp
+++ b/example/cfg/parallel_runner.cpp
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <algorithm>
+#include <boost/ut.hpp>
+#include <iostream>
+#if __has_include(<execution>)
+#include <execution>
+#endif
+
+namespace ut = boost::ut;
+
+namespace cfg {
+class parallel_runner : public ut::runner<> {
+ public:
+  using ut::runner<>::on;
+
+  template <class... Ts>
+  auto on(ut::events::test<Ts...> test) {
+    std::clog << test.name << '\n';
+    ut::runner<>::on(test);
+  }
+
+  [[nodiscard]] auto run() -> bool {
+#if defined(__cpp_lib_parallel_algorithm)
+    std::for_each(std::execution::par, std::cbegin(suites_), std::cend(suites_),
+                  [&](const auto& suite) { suite(); });
+#else
+    std::for_each(std::cbegin(suites_), std::cend(suites_),
+                  [&](const auto& suite) { suite(); });
+#endif
+
+    suites_.clear();
+
+    return fails_ > 0;
+  }
+};
+}  // namespace cfg
+
+template <>
+auto ut::cfg<ut::override> = cfg::parallel_runner{};
+
+ut::suite parallel_1 = [] {
+  using namespace ut;
+
+  // sequential
+  "test.1.1"_test = [] { expect(1_i == 1); };
+  "test.1.2"_test = [] { expect(2_i == 2); };
+  "test.1.3"_test = [] { expect(3_i == 3); };
+};
+
+ut::suite parallel_2 = [] {
+  using namespace ut;
+
+  // sequential
+  "test.2.1"_test = [] { expect(1_i == 1); };
+  "test.2.2"_test = [] { expect(2_i == 2); };
+  "test.2.3"_test = [] { expect(3_i == 3); };
+};
+
+int main() { return ut::cfg<ut::override>.run(); }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1398,7 +1398,7 @@ class runner {
 
   [[nodiscard]] auto run(run_cfg rc = {}) -> bool {
     run_ = true;
-    for (auto& suite : suites_) {
+    for (const auto& suite : suites_) {
       suite();
     }
     suites_.clear();


### PR DESCRIPTION
Problem:
- There is no example which shows how to run test suites in parallel.

Solution:
- Add `parallel_execution` example which leverages `std::execution::par` policy.
