### PR TITLE
:fire: :art: [ut] Remove `matcher` operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,9 +756,9 @@ asserts: 1 | 0 passed | 1 failed
 ```cpp
 "matchers"_test = [] {
   constexpr auto is_between = [](auto lhs, auto rhs) {
-    return matcher([=](auto value) {
+    return [=](auto value) {
       return that % value >= lhs and that % value <= rhs;
-    });
+    };
   };
 
   expect(is_between(1, 100)(42));
@@ -972,22 +972,6 @@ namespace boost::ut::inline v1_1_5 {
      */
     [[nodiscard]] constexpr auto operator%(Expression expr) const;
   } that{};
-
-  /**
-   * @example auto gt_0 = matcher([](auto arg){ return that % arg > 0; })
-   */
-  struct matcher {
-    /**
-     * @param expr matcher expression
-     */
-    constexpr explicit(true) matcher(Expression expr);
-
-    /**
-     * Executes matcher expression
-     * @param args arguments to be passed to a matcher expression
-     */
-    [[nodiscard]] constexpr auto operator()(const Args&... args) const;
-  };
 
   inline namespace literals {
     /**

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1658,20 +1658,6 @@ class expect_ {
  private:
   bool result_{}, fatal_{};
 };
-
-template <class TExpr>
-class matcher_ : op {
- public:
-  constexpr explicit matcher_(const TExpr& expr) : expr_{expr} {}
-
-  template <class... TArgs>
-  [[nodiscard]] constexpr auto operator()(const TArgs&... args) const {
-    return expr_(args...);
-  }
-
- private:
-  TExpr expr_{};
-};
 }  // namespace detail
 
 namespace literals {
@@ -1888,11 +1874,6 @@ template <auto Constant>
 template <bool Constant>
 #endif
 constexpr auto constant = Constant;
-
-template <class TExpr>
-[[nodiscard]] constexpr auto matcher(const TExpr& expr) {
-  return detail::matcher_<TExpr>{expr};
-}
 
 #if defined(__cpp_exceptions)
 template <class TException, class TExpr>

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -31,7 +31,7 @@ constexpr auto test_assert =
       if (not result) {
         std::cerr << sl.file_name() << ':' << sl.line() << ":FAILED"
                   << std::endl;
-        throw;
+        std::abort();
       }
     };
 
@@ -788,7 +788,7 @@ int main() {
     test_cfg = fake_cfg{};
 
     constexpr auto is_gt = [](auto N) {
-      return matcher([=](auto value) { return that % value > N; });
+      return [=](auto value) { return that % value > N; };
     };
 
     expect(is_gt(42)(99));


### PR DESCRIPTION
Problem:
- `matcher` operator is not required.

Solution:
- Remove it and update examples without using it.