### PR TITLE
:bug: [ut] Fix  issue with detecting availability of `source_location`

### DIFF
--- a/example/matcher.cpp
+++ b/example/matcher.cpp
@@ -66,7 +66,7 @@ int main() {
         return matcher{{}, str.str()};
       }
       return matcher{std::equal(ext.rbegin(), ext.rend(), arg.rbegin()),
-                      str.str()};
+                     str.str()};
     };
 
     auto value = 42;

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -37,10 +37,6 @@ export import std;
 #elif not defined(__cpp_static_assert)
 #error "[Boost].UT requires support for static assert";
 #else
-#if not defined(__has_builtin)
-#define __has_builtin(...) 0
-#endif
-
 #define BOOST_UT_VERSION 1'1'5
 
 #if defined(BOOST_UT_FORWARD)
@@ -214,7 +210,7 @@ namespace reflection {
 class source_location {
  public:
   [[nodiscard]] static constexpr auto current(
-#if (__has_builtin(__builtin_FILE) and __has_builtin(__builtin_LINE))
+#if ((__GNUC__ >= 9 or __clang_major__ >= 9) and not defined(__APPLE__))
       const char* file = __builtin_FILE(), int line = __builtin_LINE()
 #else
       const char* file = "unknown", int line = {}

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1343,7 +1343,7 @@ int main() {
     test_assert("2 == 2" == test_cfg.assertion_calls[1].expr);
   }
 
-#if (__has_builtin(__builtin_FILE) and __has_builtin(__builtin_LINE))
+#if ((__GNUC__ >= 9 or __clang_major__ >= 9) and not defined(__APPLE__))
   {
     test_cfg = fake_cfg{};
 


### PR DESCRIPTION
Problem:
- `source_location` is using `__has_builtin` to detect whether `source_location` is available which is reliably.

Solution:
- Use `compiler` information instead.
