### PR TITLE
:books: [README] Fix broken `matcher` godbolt link

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,7 @@ asserts: 1 | 0 passed | 1 failed
 All tests passed (2 asserts in 1 tests)
 ```
 
-> https://godbolt.org/z/oEzRsi
+> https://godbolt.org/z/4qwrCi
 
 </p>
 </details>


### PR DESCRIPTION
Problem:
- Godbolt link to the `matcher` example doesn't compile because matcher
was removed.

Solution:
- Fix the link by removing matcher from the example.