### PR TITLE
:arrow_up: [version] Bump version to `1.1.6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,7 +910,7 @@ int main() {
 ```cpp
 export module boost.ut; /// __cpp_modules
 
-namespace boost::ut::inline v1_1_5 {
+namespace boost::ut::inline v1_1_6 {
   /**
    * Represents test suite object
    */
@@ -1257,7 +1257,7 @@ namespace boost::ut::inline v1_1_5 {
 
 | Option | Description | Example |
 |-|-|-|
-| `BOOST_UT_VERSION`        | Current version | `1'1'5` |
+| `BOOST_UT_VERSION`        | Current version | `1'1'6` |
 | `BOOST_UT_FORWARD`        | Optionally used in `.cpp` files to speed up compilation of multiple suites | |
 | `BOOST_UT_IMPLEMENTATION` | Optionally used in `main.cpp` file to provide `ut` implementation (have to be used in combination with `BOOST_UT_FORWARD`) | |
 

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -37,7 +37,7 @@ export import std;
 #elif not defined(__cpp_static_assert)
 #error "[Boost].UT requires support for static assert";
 #else
-#define BOOST_UT_VERSION 1'1'5
+#define BOOST_UT_VERSION 1'1'6
 
 #if defined(BOOST_UT_FORWARD)
 namespace std {
@@ -76,7 +76,7 @@ export namespace boost::ut {
 namespace boost::ut {
 #endif
 
-inline namespace v1_1_5 {
+inline namespace v1_1_6 {
 namespace utility {
 class string_view {
  public:
@@ -1998,6 +1998,6 @@ using operators::operator and;
 using operators::operator or;
 using operators::operator not;
 using operators::operator|;
-}  // namespace v1_1_5
+}  // namespace v1_1_6
 }  // namespace boost::ut
 #endif


### PR DESCRIPTION
Problem:
- There are new features which aren't tagged in `1.1.5` version.

Solution:
- Update version to `1.1.6`