### PR TITLE
:bug: [gcc-9.2.0_2] Source-file-location fails on macOS, giving 'unkn…

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -39,7 +39,7 @@ export import std;
 #else
 #define BOOST_UT_VERSION 1'1'6
 
-#if not defined(__has_builtin)
+#if not defined(__has_builtin) or (defined(__has_builtin) and (__GNUC__ == 9))
 #if (__GNUC__ >= 9)
 #define __has___builtin_FILE 1
 #define __has___builtin_LINE 1


### PR DESCRIPTION
…own' #291

Problem:
- `gcc-9.2.0_2` defines `__has_builtin` however `__has_builtin(__builtin_FILE)` returns 0.

Solution:
- Set `__has___builtin_FILE` and `__has___builtin_FILE` to 1 in case of GCC-9 although `__has_builtin` is defined.