### PR TITLE
:bug: [gcc-9/apple] Fix for `__has_builtin` defined to 0

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -39,7 +39,11 @@ export import std;
 #else
 #define BOOST_UT_VERSION 1'1'6
 
-#if not defined(__has_builtin) or (defined(__has_builtin) and (__GNUC__ == 9))
+#if defined(__has_builtin) and (__GNUC__ < 10) and not defined(__clang__)
+#undef __has_builtin
+#endif
+
+#if not defined(__has_builtin)
 #if (__GNUC__ >= 9)
 #define __has___builtin_FILE 1
 #define __has___builtin_LINE 1


### PR DESCRIPTION
Problem:
- Apple defines `__has_builtin` to 0.

Solution:
- Undefine `__has_builtin` when Apple is detected.
