### PR TITLE
Return non-zero exit status after unexpected exceptions.

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1347,9 +1347,11 @@ class runner {
       } catch (const std::exception& e) {
         reporter_.on(events::exception{e.what()});
         active_exception_ = true;
+        ++fails_;
       } catch (...) {
         reporter_.on(events::exception{"Unknown exception"});
         active_exception_ = true;
+        ++fails_;
       }
 #endif
 


### PR DESCRIPTION
Problem:
- See description #299.

Solution:
- `~runner()` contains the following code:
```c++
    if (should_run and fails_) {
      std::exit(-1);
    }
```
- Previously, if there were any uncaught exceptions, they did not increment `fails_`
- I've changed the code so that in the two places where unexpected exceptions are caught, `fails_` is incremented.

**Testing done**

- With this change, the exampled code given in the linked issue gives:
```
.../ut-claremacrae/cmake-build-spaces/cmake-build-debug-gcc9-brew/example/exception
Running "exceptions"...
  Unexpected exception with message:
no!
FAILED

===============================================================================
tests:   1 | 1 failed
asserts: 0 | 0 passed | 0 failed


Process finished with exit code 255
```

Note that the exit code is now 255, not 0.

**Unit testing - no change**

Unchanged... I spent some time reading the tests in ut.cpp, but didn't succeed in understanding enough about the structure of the current tests to spot how to add a test for this change.

I saw that this is probably the right area... But not how to add a test that threw an exception, in the style of the current tests...

```cpp
  {
    struct test_runner : runner<test_reporter> {
      using runner::active_exception_;
      using runner::reporter_;
      using runner::run_;
      using runner::operator=;
    };

    auto run = test_runner{};
    auto& reporter = run.reporter_;
    run.run_ = true;
```

Issue: #299

Reviewers:
@
