### PR TITLE
Security fix

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -188,7 +188,7 @@ class function<R(TArgs...)> {
   }
 
   if (pattern[0] == '*') {
-    for (auto i = 0u; i <= std::size(input); ++i) {
+    for (decltype(std::size(input)) i = 0u; i <= std::size(input); ++i) {
       if (is_match(input.substr(i), pattern.substr(1))) {
         return true;
       }


### PR DESCRIPTION
`auto i = 0u` means that the type of `i` is `unsigned` which is 32-bit on MSVC. However, `std::size(input)` returns `std::size_t` which is 64-bit on MSVC x64. This means `++i` will result in integer overflow when it reaches 2^32.

Problem:
The type of `i` is 32-bit, but it is compared to 64-bit value which can result in the integer overflow.

Solution:
Make the type of `i` corresponding to `std::size(input)`

Reviewers:
@
