### PR TITLE
:bug: :art: :racehorse: [ut] `std::empty(pattern)` check is redundant…

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -178,9 +178,7 @@ class function<R(TArgs...)> {
   }
 
   if (std::empty(input)) {
-    return std::empty(pattern) or pattern[0] == '*'
-               ? is_match(input, pattern.substr(1))
-               : false;
+    return pattern[0] == '*' ? is_match(input, pattern.substr(1)) : false;
   }
 
   if (pattern[0] != '?' and pattern[0] != '*' and pattern[0] != input[0]) {


### PR DESCRIPTION
…, Fix #307

Problem:
- `std::empty(pattern)` check is redundant.

Solution:
- Remove it.