### PR TITLE
:books: [README] Godbolt link to `how-does-it-work`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1415,6 +1415,8 @@ namespace boost::ut::inline v1_1_6 {
   constexpr auto then   = [](const auto name) { return test{name}; };
   ```
 
+> https://godbolt.org/z/6Nk5Mi
+
 </p>
 </details>
 


### PR DESCRIPTION
Problem:
- README doesn't have godbolt link to `how-does-it-work`.

Solution:
- Add link to godbolt.