### PR TITLE
:new: [ut] Add `""_b` named boolean expression

### DIFF
--- a/example/expect.cpp
+++ b/example/expect.cpp
@@ -102,4 +102,10 @@ int main() {
     expect(bool(std::make_unique<int>()));
     expect(not bool(std::unique_ptr<int>{}));
   };
+
+  "boolean"_test = [] {
+    expect("true"_b);
+    expect("true"_b and not false_b);
+    expect(not"true"_b == false_b);
+  };
 }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1976,6 +1976,9 @@ struct suite {
 
 [[maybe_unused]] constexpr auto true_b = detail::integral_constant<true>{};
 [[maybe_unused]] constexpr auto false_b = detail::integral_constant<false>{};
+constexpr auto operator""_b(const char*, decltype(sizeof(""))) {
+  return true_b;
+}
 
 [[maybe_unused]] inline auto log = detail::log{};
 [[maybe_unused]] inline auto that = detail::that_{};

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -197,6 +197,7 @@ int main() {
   {
     static_assert(true_b);
     static_assert(not false_b);
+    static_assert("named"_b);
     static_assert(42 == 42_i);
     static_assert(0u == 0_u);
     static_assert(42u == 42_u);


### PR DESCRIPTION
Problem:
- Use `true_b/false_` doesn't say much about the intent.

Solution:
- Named boolean expressions makes it convenient and cleaner.