### PR TITLE
:art: [ut] `expect` should be treated as an operator

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1678,13 +1678,13 @@ struct that_ {
 };
 
 template <class T>
-class expect_ {
+class expect_ : op {
  public:
-  constexpr explicit expect_(bool result) : result_{result} {}
+  constexpr explicit expect_(bool value) : value_{value} {}
 
   template <class TMsg>
   auto& operator<<(const TMsg& msg) {
-    if (not result_) {
+    if (not value_) {
       on<T>(events::log{' '});
       on<T>(events::log{msg});
     }
@@ -1697,13 +1697,13 @@ class expect_ {
   }
 
   ~expect_() noexcept(false) {
-    if (not result_ and fatal_) {
+    if (not value_ and fatal_) {
       on<T>(events::fatal_assertion{});
     }
   }
 
  private:
-  bool result_{}, fatal_{};
+  bool value_{}, fatal_{};
 };
 }  // namespace detail
 


### PR DESCRIPTION
Problem:
- expect is not an operator but it should be to allow `!expect(ptr) and expect(ptr)`.

Solution:
- Inherit from `op` to allow `expect` to be treated as an operator.
- Unify naming and add the explicit conversion to bool.