### PR TITLE
:new: [operators] Support for `in-place` assertions

### DIFF
--- a/example/BDD.cpp
+++ b/example/BDD.cpp
@@ -8,8 +8,10 @@
 #include <boost/ut.hpp>
 
 int main() {
-  using namespace boost::ut;
+  using namespace boost::ut::operators;
+  using namespace boost::ut::literals;
   using namespace boost::ut::bdd;
+  using boost::ut::expect;
 
   "Scenario"_test = [] {
     given("I have...") = [] {

--- a/example/expect.cpp
+++ b/example/expect.cpp
@@ -108,4 +108,9 @@ int main() {
     expect("true"_b and not false_b);
     expect(not"true"_b == false_b);
   };
+
+  "in-place"_test = [] {
+    42_i == sum(40, 2);
+    sum(1, 2, 3) == 6_i;
+  };
 }

--- a/example/spec.cpp
+++ b/example/spec.cpp
@@ -10,8 +10,10 @@
 constexpr auto sum = [](auto... args) { return (0 + ... + args); };
 
 int main() {
-  using namespace boost::ut;
+  using namespace boost::ut::operators;
+  using namespace boost::ut::literals;
   using namespace boost::ut::spec;
+  using boost::ut::expect;
 
   describe("sum") = [] {
     it("should be 0") = [] { expect(sum() == 0_i); };

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -310,7 +310,7 @@ int main() {
     test_assert("0 >= 0" == to_string(0_s >= _s(0)));
     test_assert("0 <= 0" == to_string(0_s <= _s(0)));
     test_assert("0 != 0" == to_string(0_s != _s(0)));
-    test_assert("not 0" == to_string(!0_s));
+    test_assert("not true" == to_string(!"true"_b));
     test_assert("42 == 42" == to_string(42_i == 42));
     test_assert("42 != 42" == to_string(42_i != 42));
     test_assert("42 > 0" == to_string(42_ul > 0_ul));
@@ -1266,10 +1266,10 @@ int main() {
     test_assert(test_cfg.assertion_calls[1].result);
     test_assert(test_cfg.assertion_calls[2].result);
     test_assert(test_cfg.assertion_calls[3].result);
-    test_assert("(42 == 42 or 42 == x)" == test_cfg.assertion_calls[0].expr);
+    test_assert("(42 == 42 or * == x)" == test_cfg.assertion_calls[0].expr);
     test_assert("(int == int or int == char)" ==
                 test_cfg.assertion_calls[1].expr);
-    test_assert("(42 == x or x == x)" == test_cfg.assertion_calls[2].expr);
+    test_assert("(42 == 120 or x == x)" == test_cfg.assertion_calls[2].expr);
     test_assert("(char == int or char == char)" ==
                 test_cfg.assertion_calls[3].expr);
   }


### PR DESCRIPTION
Problem:
- `expect` is not required for the verification. Literals + operators are enough.

Solution:
- Add support for `in-place` assertions.

Example:

```
"sum"_test = [] {
  42_i == sum(40, 2);
};
```
