### PR TITLE
:new: [terse] Support for comparing objects with `%_t` notation

### DIFF
--- a/example/terse.cpp
+++ b/example/terse.cpp
@@ -9,6 +9,19 @@
 
 constexpr auto sum = [](auto... args) { return (0 + ... + args); };
 
+struct foo {
+  int a{};
+  bool b{};
+
+  constexpr auto operator==(const foo& other) {
+    return a == other.a and b == other.b;
+  }
+
+  friend auto& operator<<(std::ostream& os, const foo& f) {
+    return (os << "foo{" << f.a << ',' << f.b << '}');
+  }
+};
+
 int main() {
   using boost::ut::operator""_test;
   using namespace boost::ut::literals;
@@ -18,5 +31,10 @@ int main() {
     6_i == sum(1, 2, 3);
     sum(1, 1) == 2_i;
     42_i == sum(40, 2) and 0_i != sum(1) or 4_i == 3;
+  };
+
+  "terse types"_test = [] {
+    foo{42, true} % _t == foo{42, true};
+    foo{42, true} == foo{42, true} % _t;
   };
 }

--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1971,6 +1971,14 @@ namespace terse {
 #pragma clang diagnostic ignored "-Wunused-comparison"
 #endif
 
+static inline struct {
+} _t;
+
+template <class T>
+constexpr auto operator%(const T& lhs, const decltype(_t)&) {
+  return detail::value<T>{lhs};
+}
+
 template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
 constexpr auto operator==(
     const T& lhs, const detail::value_location<typename T::value_type>& rhs) {

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1423,8 +1423,9 @@ int main() {
     0_i == 1 and 1_i > 2 or 3 <= 3_i;
     !expect(boost::ut::true_b == false) and 1_i > 0;
     2 == 1_i;
+    custom{42} % _t == custom{41};
 
-    test_assert(7 == std::size(test_cfg.assertion_calls));
+    test_assert(8 == std::size(test_cfg.assertion_calls));
     test_assert(test_cfg.fatal_assertion_calls > 0);
 
     test_assert("42 == 42" == test_cfg.assertion_calls[0].expr);
@@ -1448,5 +1449,8 @@ int main() {
 
     test_assert("2 == 1" == test_cfg.assertion_calls[6].expr);
     test_assert(not test_cfg.assertion_calls[6].result);
+
+    test_assert("custom{42} == custom{41}" == test_cfg.assertion_calls[7].expr);
+    test_assert(not test_cfg.assertion_calls[7].result);
   }
 }


### PR DESCRIPTION
Problem:
- There is no easy way to compare custom types with terse notation.

Solution:
- Add `%_t` notation to simplify the comparison.
- Extend `terse` example.

Example:

```
foo{43, true}%_t == foo{42, true}; // FAILED:__LINE__: foo{43, true} == foo{42, true}
```