### PR TITLE
:art: [ut] Apply `[[maybe_unused]]` for locally defined types

### DIFF
--- a/include/boost/ut.hpp
+++ b/include/boost/ut.hpp
@@ -1985,7 +1985,7 @@ constexpr auto operator==(
   using eq_t =
       ut::detail::eq_<T, detail::value_location<typename T::value_type>>;
   struct eq_ : eq_t {
-    using type = eq_t;
+    using type [[maybe_unused]] = eq_t;
     using eq_t::eq_t;
     const detail::terse_<eq_t> _{*this};
   };
@@ -1998,7 +1998,7 @@ constexpr auto operator==(
   using eq_t =
       ut::detail::eq_<detail::value_location<typename T::value_type>, T>;
   struct eq_ : eq_t {
-    using type = eq_t;
+    using type [[maybe_unused]] = eq_t;
     using eq_t::eq_t;
     const detail::terse_<eq_t> _{*this};
   };
@@ -2011,7 +2011,7 @@ constexpr auto operator!=(
   using neq_t =
       ut::detail::neq_<T, detail::value_location<typename T::value_type>>;
   struct neq_ : neq_t {
-    using type = neq_t;
+    using type [[maybe_unused]] = neq_t;
     using neq_t::neq_t;
     const detail::terse_<neq_t> _{*this};
   };
@@ -2024,7 +2024,7 @@ constexpr auto operator!=(
   using neq_t =
       ut::detail::neq_<detail::value_location<typename T::value_type>, T>;
   struct neq_ : neq_t {
-    using type = neq_t;
+    using type [[maybe_unused]] = neq_t;
     using neq_t::neq_t;
     const detail::terse_<neq_t> _{*this};
   };
@@ -2037,7 +2037,7 @@ constexpr auto operator>(
   using gt_t =
       ut::detail::gt_<T, detail::value_location<typename T::value_type>>;
   struct gt_ : gt_t {
-    using type = gt_t;
+    using type [[maybe_unused]] = gt_t;
     using gt_t::gt_t;
     const detail::terse_<gt_t> _{*this};
   };
@@ -2050,7 +2050,7 @@ constexpr auto operator>(
   using gt_t =
       ut::detail::gt_<detail::value_location<typename T::value_type>, T>;
   struct gt_ : gt_t {
-    using type = gt_t;
+    using type [[maybe_unused]] = gt_t;
     using gt_t::gt_t;
     const detail::terse_<gt_t> _{*this};
   };
@@ -2063,7 +2063,7 @@ constexpr auto operator>=(
   using ge_t =
       ut::detail::ge_<T, detail::value_location<typename T::value_type>>;
   struct ge_ : ge_t {
-    using type = ge_t;
+    using type [[maybe_unused]] = ge_t;
     using ge_t::ge_t;
     const detail::terse_<ge_t> _{*this};
   };
@@ -2076,7 +2076,7 @@ constexpr auto operator>=(
   using ge_t =
       ut::detail::ge_<detail::value_location<typename T::value_type>, T>;
   struct ge_ : ge_t {
-    using type = ge_t;
+    using type [[maybe_unused]] = ge_t;
     using ge_t::ge_t;
     const detail::terse_<ge_t> _{*this};
   };
@@ -2089,7 +2089,7 @@ constexpr auto operator<(
   using lt_t =
       ut::detail::lt_<T, detail::value_location<typename T::value_type>>;
   struct lt_ : lt_t {
-    using type = lt_t;
+    using type [[maybe_unused]] = lt_t;
     using lt_t::lt_t;
     const detail::terse_<lt_t> _{*this};
   };
@@ -2102,7 +2102,7 @@ constexpr auto operator<(
   using lt_t =
       ut::detail::lt_<detail::value_location<typename T::value_type>, T>;
   struct lt_ : lt_t {
-    using type = lt_t;
+    using type [[maybe_unused]] = lt_t;
     using lt_t::lt_t;
     const detail::terse_<lt_t> _{*this};
   };
@@ -2115,7 +2115,7 @@ constexpr auto operator<=(
   using le_t =
       ut::detail::le_<T, detail::value_location<typename T::value_type>>;
   struct le_ : le_t {
-    using type = le_t;
+    using type [[maybe_unused]] = le_t;
     using le_t::le_t;
     const detail::terse_<le_t> _{*this};
   };
@@ -2128,7 +2128,7 @@ constexpr auto operator<=(
   using le_t =
       ut::detail::le_<detail::value_location<typename T::value_type>, T>;
   struct le_ : le_t {
-    using type = le_t;
+    using type [[maybe_unused]] = le_t;
     using le_t::le_t;
     const detail::terse_<le_t> _{*this};
   };
@@ -2141,7 +2141,7 @@ template <class TLhs, class TRhs,
 constexpr auto operator and(const TLhs& lhs, const TRhs& rhs) {
   using and_t = ut::detail::and_<typename TLhs::type, typename TRhs::type>;
   struct and_ : and_t {
-    using type = and_t;
+    using type [[maybe_unused]] = and_t;
     using and_t::and_t;
     const detail::terse_<and_t> _{*this};
   };
@@ -2154,7 +2154,7 @@ template <class TLhs, class TRhs,
 constexpr auto operator or(const TLhs& lhs, const TRhs& rhs) {
   using or_t = ut::detail::or_<typename TLhs::type, typename TRhs::type>;
   struct or_ : or_t {
-    using type = or_t;
+    using type [[maybe_unused]] = or_t;
     using or_t::or_t;
     const detail::terse_<or_t> _{*this};
   };
@@ -2165,7 +2165,7 @@ template <class T, type_traits::requires_t<type_traits::is_op_v<T>> = 0>
 constexpr auto operator not(const T& t) {
   using not_t = ut::detail::not_<typename T::type>;
   struct not_ : not_t {
-    using type = not_t;
+    using type [[maybe_unused]] = not_t;
     using not_t::not_t;
     const detail::terse_<not_t> _{*this};
   };


### PR DESCRIPTION
Problem:
- GCC complaints about locally unused type.

Solution:
- Apply `[[maybe_unused]]`` to locally defined types.