### PR TITLE
:lipstick: [terse] Disable clang-format for `%_t` notation

### DIFF
--- a/example/terse.cpp
+++ b/example/terse.cpp
@@ -33,8 +33,10 @@ int main() {
     42_i == sum(40, 2) and 0_i != sum(1) or 4_i == 3;
   };
 
+  // clang-format off
   "terse types"_test = [] {
-    foo{42, true} % _t == foo{42, true};
+    foo{42, true}%_t == foo{42, true};
     foo{42, true} == foo{42, true} % _t;
   };
+  // clang-format on
 }

--- a/test/ut/ut.cpp
+++ b/test/ut/ut.cpp
@@ -1418,12 +1418,14 @@ int main() {
 
     test_cfg = fake_cfg{};
 
+    // clang-format off
     42_i == 42;
     1 == 2_i;
     0_i == 1 and 1_i > 2 or 3 <= 3_i;
     !expect(boost::ut::true_b == false) and 1_i > 0;
     2 == 1_i;
-    custom{42} % _t == custom{41};
+    custom{42}%_t == custom{41};
+    // clang-format on
 
     test_assert(8 == std::size(test_cfg.assertion_calls));
     test_assert(test_cfg.fatal_assertion_calls > 0);


### PR DESCRIPTION
Problem:
- clang-format changes `%_t` into ` % _t`.

Solution:
- Disable clang-format around usage of `%_t`.