### PR TITLE
Add missing returns to satisfy operator== nodiscard rule

### DIFF
--- a/example/BDD.cpp
+++ b/example/BDD.cpp
@@ -15,8 +15,8 @@ int main() {
   "Scenario"_test = [] {
     given("I have...") = [] {
       when("I run...") = [] {
-        then("I should have...") = [] { 1_u == 1u; };
-        then("I should have...") = [] { 1u == 1_u; };
+        then("I should have...") = [] { return 1_u == 1u; };
+        then("I should have...") = [] { return 1u == 1_u; };
       };
     };
   };


### PR DESCRIPTION
Missing return statements cause g++-10 to fail since operator== is nodiscard
