### PR TITLE
:bug: [example] `BDD` example should use terse operators

### DIFF
--- a/example/BDD.cpp
+++ b/example/BDD.cpp
@@ -8,8 +8,8 @@
 #include <boost/ut.hpp>
 
 int main() {
-  using namespace boost::ut::operators;
   using namespace boost::ut::literals;
+  using namespace boost::ut::operators::terse;
   using namespace boost::ut::bdd;
 
   "Scenario"_test = [] {


### PR DESCRIPTION
Problem:
- `terse` operators are [[nodiscard]] and they result is based on the operation side offect.

Solution:
- Use `operators::terse` in BDD example.