### PR TITLE
:new: [example] `micro-benchmarking`, Fix #276

### DIFF
--- a/README.md
+++ b/README.md
@@ -1612,6 +1612,19 @@ All tests passed (4 asserts in 3 tests)
 </p>
 </details>
 
+<details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;What about Microbenchmarking?</summary>
+<p>
+
+> Consider using one of the following frameworks
+
+* https://github.com/google/benchmark
+* https://github.com/DigitalInBlue/Celero
+* https://github.com/libnonius/nonius
+* https://github.com/martinus/nanobench
+
+</p>
+</details>
+
 </p>
 </details>
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,6 +38,7 @@ if (NOT WIN32)
 endif()
 
 example(BDD BDD)
+example(benchmark benchmark)
 example(cli cli_pass "cli.pass")
 example(cli cli_pass_no_colors "cli.pass" "0" "1")
 example(cli cli_pass_dry_run "cli.pass" "1" "1")

--- a/example/benchmark.cpp
+++ b/example/benchmark.cpp
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2019-2020 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/ut.hpp>
+#include <chrono>
+#include <iostream>
+#include <string>
+
+namespace benchmark {
+struct benchmark : boost::ut::detail::test {
+  template <class TName>
+  constexpr explicit benchmark(const TName& name)
+      : boost::ut::detail::test{"benchmark", name} {}
+
+  template <class Test>
+  constexpr auto operator=(Test test) {
+    static_cast<boost::ut::detail::test&>(*this) = [&test, this] {
+      const auto start = std::chrono::high_resolution_clock::now();
+      test();
+      const auto stop = std::chrono::high_resolution_clock::now();
+      const auto ns =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start);
+      std::clog << "[" << name << "] " << ns.count() << " ns\n";
+    };
+  }
+};
+
+[[nodiscard]] constexpr auto operator""_benchmark(const char* name,
+                                                  decltype(sizeof("")) size) {
+  return ::benchmark::benchmark{boost::ut::utility::string_view{name, size}};
+}
+
+#if defined(__GNUC__) or defined(__clang__)
+template <class T>
+void do_not_optimize(T&& t) {
+  asm volatile("" ::"m"(t) : "memory");
+}
+#else
+#pragma optimize("", off)
+template <class T>
+void do_not_optimize(T&& t) {
+  reinterpret_cast<char volatile&>(t) =
+      reinterpret_cast<char const volatile&>(t);
+}
+#pragma optimize("", on)
+#endif
+}  // namespace benchmark
+
+int main() {
+  using namespace boost::ut;
+  using namespace benchmark;
+
+  "string creation"_benchmark = [] {
+    std::string created_string{"hello"};
+    do_not_optimize(created_string);
+  };
+}


### PR DESCRIPTION
Problem:
- UT doesn't support micro-benchmarking out of the box.
- There is no info about micro-benchmarking in `README`.

Solution:
- Add example how to add/integrate micro-benchamarking with UT.
- Add C++ micro-benchmarking libraries to `README` `FAQ`.