### PR TITLE
Allow disabling benchmarks, examples and tests in top-level builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ project(boost.ut CXX)
 
 include(CTest)
 
+set(MASTER_PROJECT OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(MASTER_PROJECT ON)
+endif()
+
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "Default value for CXX_STANDARD property of targets.")
 set(CMAKE_CXX_STANDARD_REQUIRED yes CACHE BOOL "Default value for CXX_STANDARD_REQUIRED property of targets.")
 set(CMAKE_CXX_EXTENSIONS no CACHE BOOL "Default value for CXX_EXTENSIONS property of targets.")
@@ -16,10 +21,9 @@ option(BOOST_UT_ENABLE_MEMCHECK "Run the unit tests and examples under valgrind 
 option(BOOST_UT_ENABLE_COVERAGE "Run coverage" OFF)
 option(BOOST_UT_ENABLE_SANITIZERS "Run static analysis" OFF)
 option(BOOST_UT_ENABLE_RUN_AFTER_BUILD "Automatically run built artifacts. If disabled, the tests can be run with ctest instead" ON)
-# Non-cache variables
-# BOOST_UT_BUILD_BENCHMARKS: Enable building the benchmarks
-# BOOST_UT_BUILD_EXAMPLES: Enable building the examples
-# BOOST_UT_BUILD_TESTS: Enable building the tests
+option(BOOST_UT_BUILD_BENCHMARKS "Build the benchmarks" ${MASTER_PROJECT})
+option(BOOST_UT_BUILD_EXAMPLES "Build the examples" ${MASTER_PROJECT})
+option(BOOST_UT_BUILD_TESTS "Build the tests" ${MASTER_PROJECT})
 
 add_library(boost.ut INTERFACE)
 target_include_directories(boost.ut INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
@@ -126,13 +130,13 @@ endfunction()
 
 include_directories(include)
 
-if (BOOST_UT_BUILD_BENCHMARKS OR PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if (BOOST_UT_BUILD_BENCHMARKS)
   add_subdirectory(benchmark)
 endif()
-if (BOOST_UT_BUILD_EXAMPLES OR PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if (BOOST_UT_BUILD_EXAMPLES)
   add_subdirectory(example)
 endif()
-if (BOOST_UT_BUILD_TESTS OR PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if (BOOST_UT_BUILD_TESTS)
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
## Problem
It's impossible to disable building benchmarks, examples and tests in top-level builds. When packaging this is quite undesirable, as this results in having to build tons of irrelevant targets.

## Solution
Make the relevant flags cache variables so they can be overridden for such builds.  
Uses the same logic as before for setting the default values.