### PR TITLE
CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(BOOST_UT_BUILD_TESTS "Build the tests" ${MASTER_PROJECT})
 
 add_library(boost.ut INTERFACE)
 target_include_directories(boost.ut INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+add_library(boost::ut ALIAS boost.ut)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   if (WIN32) # clang-cl
@@ -140,4 +141,28 @@ if (BOOST_UT_BUILD_TESTS)
   add_subdirectory(test)
 endif()
 
-install(FILES include/boost/ut.hpp DESTINATION include/boost/)
+## Packaging.
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(package_directory "${CMAKE_INSTALL_LIBDIR}/cmake/ut")
+set(config_output "${CMAKE_CURRENT_BINARY_DIR}/ut-config.cmake")
+
+# Generate config file.
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/ut-config.cmake.in"
+  "${config_output}"
+  INSTALL_DESTINATION "${package_directory}"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+# Install includes, config and targets.
+install(
+  FILES include/boost/ut.hpp
+  DESTINATION include/boost/
+)
+install(
+  FILES "${config_output}"
+  DESTINATION "${package_directory}"
+)

--- a/cmake/ut-config.cmake.in
+++ b/cmake/ut-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET boost::ut)
+	add_library(boost::ut INTERFACE IMPORTED)
+	set_target_properties(boost::ut PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include")
+	target_compile_features(boost::ut INTERFACE cxx_std_17)
+endif()


### PR DESCRIPTION
Allows packaging μt in distributions and easily using it in other programs using `find_package()`.

E.g.
```
find_package(ut)
target_link_libraries(my_thing PRIVATE boost::ut)
```

`boost.ut` target was named to `ut` to result in the correct imported target name (`boost::ut`).
Testing target `ut` was renamed to `ut.test` to avoid a naming conflict.