### PR TITLE
:books: [README] FAQ - fix benchmark link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1486,7 +1486,7 @@ namespace boost::ut::inline v1_1_7 {
 </details>
 
 <a name="fast-compilation-times"></a>
-<details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;Fast compilation times ([Benchmarks](#benchmarks))?</summary>
+<details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;Fast compilation times <a href="#benchmarks">(Benchmarks)</a>?</summary>
 <p>
 
 > Implementation


### PR DESCRIPTION
Problem:
- Benchmark link is broken in Fast compilation times section.

Solution:
- Fix it by using `a href` instead of Markdown.