### PR TITLE
:white_check_mark: [MSVC 2019 Preview] Implicitly included concepts h…

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,17 +16,20 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
       PLATFORM: amd64
+      CXX_STANDARD: 17
       CMAKE_GENERATOR: Ninja
       CXX: clang-cl
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
       PLATFORM: amd64
+      CXX_STANDARD: 20
       CMAKE_GENERATOR: Visual Studio 16 2019
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
       VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
       PLATFORM: amd64
+      CXX_STANDARD: 20
       CMAKE_GENERATOR: Visual Studio 16 2019
 
 install:
@@ -38,7 +41,7 @@ install:
   - call "%VSPATH%"\vcvarsall %PLATFORM%
 
 before_build:
-  - cmake -G "%CMAKE_GENERATOR%" -Bbuild -H.
+  - cmake -DCMAKE_CXX_STANDARD="%CXX_STANDARD%" -G "%CMAKE_GENERATOR%" -Bbuild -H.
 
 build_script:
   - cmake --build build


### PR DESCRIPTION
…eader doesn't compile

Problem:
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\include\concepts(16,2): error: Despite the presence of some Clang-related bits, this header currently does not support Clang. You can define _SILENCE_CLANG_CONCEPTS_MESSAGE to silence this message and acknowledge that this is unsupported.
```

Solution:
- Define `_SILENCE_CLANG_CONCEPTS_MESSAGE` for MSVC build to silent the warning for the time being.