### PR TITLE
:arrow_up: [travis/osx] Update image to `xcode11.4`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
           - libstdc++-9-dev
 
   - os: osx
-    osx_image: xcode11.3
+    osx_image: xcode11.4
     env: CXX=clang++ VARIANT=valgrind
 
 script:


### PR DESCRIPTION
Problem:
- `osx` image is out of date and flaky.

Solution:
- Update it to xcode11.3.