### PR TITLE
:books: [README] Info about benchmark example in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1756,6 +1756,8 @@ All tests passed (4 asserts in 3 tests)
 <details open><summary>&nbsp;&nbsp;&nbsp;&nbsp;What about Microbenchmarking?</summary>
 <p>
 
+> [Example benchmark](example/benchmark.cpp)
+
 > Consider using one of the following frameworks
 
 * https://github.com/google/benchmark


### PR DESCRIPTION
Problem:
- There is no info in README about benchmark example.

Solution:
- Add benchmark example to FAQ section